### PR TITLE
Fix form reset fields

### DIFF
--- a/frontend/src/components/ShiftRoleForm.js
+++ b/frontend/src/components/ShiftRoleForm.js
@@ -29,7 +29,14 @@ export default function ShiftRoleForm({ onRoleCreated }) {
         const newRole = await res.json();
         console.log("✅ Role created successfully:", newRole);
         onRoleCreated(newRole);
-        setFormData({ name: "", description: "", requirements: "" });
+        setFormData({
+          name: "",
+          location: "",
+          responsibilities: "",
+          physicalRequirements: "",
+          pointOfContact: "",
+          contactPhone: "",
+        });
       } else {
         const errorText = await res.text();
         console.error("❌ Failed to create role:", errorText);


### PR DESCRIPTION
## Summary
- ensure shift role forms reset all fields when a role is created

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module '../styles/home.css')*

------
https://chatgpt.com/codex/tasks/task_e_6841d12937ec8328beedb7085c8314eb