### PR TITLE
fix: handle missing user in markNoShow

### DIFF
--- a/backend/controllers/shiftController.js
+++ b/backend/controllers/shiftController.js
@@ -89,6 +89,9 @@ exports.markNoShow = async (req, res) => {
 
   try {
     const user = await User.findOne({ fusionAuthId: userId });
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
 
     const entry = user.volunteerShifts.find(s => s.shift.toString() === shiftId);
 


### PR DESCRIPTION
## Summary
- add missing user existence check in markNoShow controller

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6893c11f525083328c0588ff41b44f7d