### PR TITLE
Require API base URL in ShiftRoleForm

### DIFF
--- a/frontend/src/components/ShiftRoleForm.js
+++ b/frontend/src/components/ShiftRoleForm.js
@@ -22,8 +22,11 @@ export default function ShiftRoleForm({ onRoleCreated }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      // Use environment variable for API base URL
-      const apiBase = process.env.REACT_APP_API_BASE || "http://localhost:5001";
+      // Use environment variable for API base URL; fail fast if not provided
+      const apiBase = process.env.REACT_APP_API_BASE;
+      if (!apiBase) {
+        throw new Error("REACT_APP_API_BASE is not defined");
+      }
       const res = await fetch(`${apiBase}/api/shiftroles`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- require `REACT_APP_API_BASE` in `ShiftRoleForm` and throw an error if missing

## Testing
- `cd frontend && REACT_APP_API_BASE=http://localhost:5001 npm test -- --watchAll=false` *(fails: useRoutes() may be used only in the context of a <Router>)*

------
https://chatgpt.com/codex/tasks/task_e_6893c3e636788332b866ef4fcdbc9927