### PR TITLE
Include refModel when saving hourly need shifts

### DIFF
--- a/backend/controllers/hourlyNeedsController.js
+++ b/backend/controllers/hourlyNeedsController.js
@@ -50,8 +50,8 @@ exports.signUpForHourlyNeed = async (req, res) => {
 
     if (alreadySignedUp) return res.status(400).json({ message: "Already signed up" });
 
-    // Save to user record
-    user.volunteerShifts.push({ shift: id, status: "registered" });
+    // Save to user record with explicit model reference to avoid validation errors
+    user.volunteerShifts.push({ shift: id, refModel: "HourlyNeed", status: "registered" });
     user.totalHours += 1;
     await user.save();
 


### PR DESCRIPTION
## Summary
- ensure hourly needs sign-up saves volunteer shifts with `refModel: "HourlyNeed"`

## Testing
- `npm test` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6893c5e3e2fc8332b53d74d8369b4fc2